### PR TITLE
Feature/cc db statistics

### DIFF
--- a/cc-backend/openapi.yaml
+++ b/cc-backend/openapi.yaml
@@ -346,6 +346,62 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  /v1/apistatistics:
+    get:
+      operationId: getApiStatistics
+      summary: Get API statistics
+      tags:
+        - Apis
+      responses:
+        '200':
+          description: Get API statistics
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetApiStatistic'
+        '404':
+          description: Not found
+        '500':
+          description: Service error
+    post:
+      operationId: postApiStatistics
+      summary: Post API statistics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostApiStatistic'
+        required: true
+      tags:
+        - Apis
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Not found
+        '500':
+          description: Service error
+
+  /v1/users/count:
+    get:
+      operationId: getUserCount
+      summary: Get user count
+      tags:
+        - Users
+      responses:
+        '200':
+          description: Get user count
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUserCount'
+        '404':
+          description: Not found
+        '500':
+          description: Service error
 components:
   securitySchemes:
     bearerAuth:
@@ -577,3 +633,38 @@ components:
           type: string        
         username:          
           type: string
+
+    GetApiStatistic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        api:
+          type: string
+          format: uuid
+        success:
+          type: boolean
+        statisticType:
+          type: string
+        timeStamp:
+          type: string
+    PostApiStatistic:
+      type: object
+      required:
+        - api
+        - success
+        - statisticType
+      properties:
+        api:
+          type: string
+          format: uuid
+        success:
+          type: boolean
+        statisticType:
+          type: string
+    GetUserCount:
+      type: object
+      properties:
+        count:
+          type: number

--- a/cc-backend/src/routes/advertRoutes.ts
+++ b/cc-backend/src/routes/advertRoutes.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { postAdvert, getToken } from '../utils';
+import { postAdvert, getToken, postMTStatistics } from '../utils';
 import { Error, ItemInfo, Item, AdvertData } from '../types';
 
 const advertRouter = Router();
@@ -22,10 +22,12 @@ advertRouter.post(
         const postToMT = await postAdvert(token, advert);
         console.log(postToMT.status);
         console.log(postToMT.data);
+        postMTStatistics(true);
         response.status(postToMT.status);
         response.json(postToMT.data);
       }
     } catch (error: any) {
+      postMTStatistics(false);
       if (!error.response) {
         console.log('Unexpected error: 500');
         response.status(500);

--- a/cc-backend/src/routes/itemRoutes.ts
+++ b/cc-backend/src/routes/itemRoutes.ts
@@ -4,7 +4,8 @@ import {
   getItemsDB,
   getItemInfo,
   postConfigToDB,
-  getToken
+  getToken,
+  postPKStatistics
 } from '../utils';
 import { Error, ItemInfo, Item } from '../types';
 
@@ -19,6 +20,11 @@ itemRouter.get(
       const userId: string = request.params.userId;
       const itemsPK = await getItemsPK(token, userId);
       //const itemsDB = await getItemsDB(request.params.userId);
+      for (let i=0;i<itemsPK.length;i++) {
+        const item = itemsPK[i];
+        postPKStatistics(item.reusableId, true);
+      }
+      
       response.json(itemsPK);
       //response.write(itemsDB);
       //response.send();
@@ -49,6 +55,7 @@ itemRouter.get(
       const token = getToken(wholeToken);
       const itemId: string = request.params.itemId;
       const item: ItemInfo = await getItemInfo(token, itemId);
+      postPKStatistics(request.params.itemId, true);
       response.json(item);
     } catch (error: any) {
       console.log(error);

--- a/cc-backend/src/utils.ts
+++ b/cc-backend/src/utils.ts
@@ -241,3 +241,46 @@ export async function getUserIdFromToken(token: string) {
     return (decodedToken as JwtPayload).userId;
   }
 }
+export async function postPKStatistics(itemId: string, success: boolean) {
+  const requestData = {
+    id: itemId,
+    success: success,
+  };
+  try {
+    const response = await axios.post(
+      `${process.env.CC_DB_SERVICE_URL}/v1/apistatistics/Purkukartoitus/unique`,
+        requestData,
+        {
+          headers: {
+            Accept: 'application/json'
+          }
+        }
+    );
+    return response;
+  }
+  catch (err:any) {
+    return null;
+  }
+  
+}
+export async function postMTStatistics(success: boolean) {
+  const requestData = {
+    success: success,
+  };
+  try {
+    const response = await axios.post(
+      `${process.env.CC_DB_SERVICE_URL}/v1/apistatistics/Materiaalitori/adverts`,
+        requestData,
+        {
+          headers: {
+            Accept: 'application/json'
+          }
+        }
+    );
+    return response;
+  }
+  catch (err:any) {
+    return null;
+  }
+  
+}

--- a/cc-db-service/migrations/20221018130025-create-api-configuration.js
+++ b/cc-db-service/migrations/20221018130025-create-api-configuration.js
@@ -17,7 +17,7 @@ module.exports = {
       },
       authEndpoint: {
         type: Sequelize.STRING,
-        allowNull: false,
+        allowNull: true,
       },
       createdAt: {
         allowNull: false,

--- a/cc-db-service/migrations/20221018151142-create-api-statistic.js
+++ b/cc-db-service/migrations/20221018151142-create-api-statistic.js
@@ -28,10 +28,6 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false,
       },
-      timeStamp: {
-        type: Sequelize.DATE,
-        allowNull: false,
-      },
       updatedAt: {
         allowNull: false,
         type: Sequelize.DATE,

--- a/cc-db-service/openapi.yaml
+++ b/cc-db-service/openapi.yaml
@@ -336,12 +336,25 @@ paths:
         '500':
           description: Service error
 
-  /v1/apistatistics:
+  /v1/apistatistics/{apiName}/{statisticType}:
     get:
       operationId: getApiStatistics
       summary: Get API statistics
       tags:
         - Apis
+      parameters:
+        - name: apiName
+          required: true
+          in: path
+          description: API name
+          schema:
+            type: string
+        - name: statisticType
+          required: true
+          in: path
+          description: Statistic type
+          schema:
+            type: string
       responses:
         '200':
           description: Get API statistics
@@ -358,6 +371,19 @@ paths:
     post:
       operationId: postApiStatistics
       summary: Post API statistics
+      parameters:
+        - name: apiName
+          required: true
+          in: path
+          description: API name
+          schema:
+            type: string
+        - name: statisticType
+          required: true
+          in: path
+          description: Statistic type
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -585,34 +611,46 @@ components:
     GetApiStatistic:
       type: object
       properties:
-        id:
+        apiName:
           type: string
-          format: uuid
-        api:
-          type: string
-          format: uuid
-        success:
-          type: boolean
         statisticType:
           type: string
-        timeStamp:
-          type: string
+        successCount:
+          type: number
+        failureCount:
+          type: number
+        daily:
+          type: array
+          items:
+            type: object
+            properties:
+              successCount:
+                type: number
+              failureCount:
+                type: number
+              date:
+                type: string
     PostApiStatistic:
       type: object
       required:
-        - api
         - success
-        - statisticType
       properties:
-        api:
+        id:
           type: string
           format: uuid
         success:
           type: boolean
-        statisticType:
-          type: string
     GetUserCount:
       type: object
       properties:
         count:
           type: number
+        daily:
+          type: array
+          items:
+            type: object
+            properties:
+              count:
+                type: number
+              date:
+                type: string

--- a/cc-db-service/openapi.yaml
+++ b/cc-db-service/openapi.yaml
@@ -336,6 +336,62 @@ paths:
         '500':
           description: Service error
 
+  /v1/apistatistics:
+    get:
+      operationId: getApiStatistics
+      summary: Get API statistics
+      tags:
+        - Apis
+      responses:
+        '200':
+          description: Get API statistics
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetApiStatistic'
+        '404':
+          description: Not found
+        '500':
+          description: Service error
+    post:
+      operationId: postApiStatistics
+      summary: Post API statistics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostApiStatistic'
+        required: true
+      tags:
+        - Apis
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Not found
+        '500':
+          description: Service error
+
+  /v1/users/count:
+    get:
+      operationId: getUserCount
+      summary: Get user count
+      tags:
+        - Users
+      responses:
+        '200':
+          description: Get user count
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUserCount'
+        '404':
+          description: Not found
+        '500':
+          description: Service error
+
 components:
   schemas:
     GetApi:
@@ -526,3 +582,37 @@ components:
           type: string
         locationMunicipality:
           type: string
+    GetApiStatistic:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        api:
+          type: string
+          format: uuid
+        success:
+          type: boolean
+        statisticType:
+          type: string
+        timeStamp:
+          type: string
+    PostApiStatistic:
+      type: object
+      required:
+        - api
+        - success
+        - statisticType
+      properties:
+        api:
+          type: string
+          format: uuid
+        success:
+          type: boolean
+        statisticType:
+          type: string
+    GetUserCount:
+      type: object
+      properties:
+        count:
+          type: number

--- a/cc-db-service/seeders/20221018153309-pk-api-config.js
+++ b/cc-db-service/seeders/20221018153309-pk-api-config.js
@@ -17,6 +17,12 @@ module.exports = {
           createdAt: new Date(),
           updatedAt: new Date(),
         },
+        {
+          id: uuidv4(),
+          name: 'Materiaalitori',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
       ],
       {}
     );

--- a/cc-db-service/seeders/20221018162715-test-data.js
+++ b/cc-db-service/seeders/20221018162715-test-data.js
@@ -28,15 +28,33 @@ module.exports = {
         updatedAt: new Date(),
       },
     ]);
-    /*await queryInterface.bulkInsert('user', [
+    await queryInterface.bulkInsert('user', [
       {
-        id: '82114f1c-ed8e-4ed0-ad2f-10b72bdcf349',
+        id: '82114f1c-ed8e-4ed0-ad2f-10b72bdcf347',
         api: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
-        name: 'karih',
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        name: 'testikari',
+        createdAt: new Date(2021, 1, 2),
+        updatedAt: new Date(2021, 1, 2),
       },
-    ]);*/
+    ]);
+    await queryInterface.bulkInsert('user', [
+      {
+        id: '82114f1c-ed8e-4ed0-ad2f-10b72bdcf341',
+        api: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        name: 'testikari2',
+        createdAt: new Date(2021, 1, 2),
+        updatedAt: new Date(2021, 1, 2),
+      },
+    ]);
+    await queryInterface.bulkInsert('user', [
+      {
+        id: '82114f1c-ed8e-4ed0-ad2f-10b72bdcf311',
+        api: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        name: 'testikari3',
+        createdAt: new Date(2021, 3, 2),
+        updatedAt: new Date(2021, 3, 2),
+      },
+    ]);
     await queryInterface.bulkInsert('item', [
       {
         id: '0cdb31e8-b330-48dd-aecc-b2a92cf3d037',
@@ -52,7 +70,7 @@ module.exports = {
       {
         id: '0cdb31e8-b330-48dd-aecc-b2a92cf3d032',
         itemId: 'some-item-id2',
-        userId: '82114f1c-ed8e-4ed0-ad2f-10b72bdcf349',
+        userId: '82114f1c-ed8e-4ed0-ad2f-10b72bdcf347',
         status: 1,
         collectionId: 'test-collection',
         createdAt: new Date(),
@@ -99,6 +117,46 @@ module.exports = {
         industry: 'Purkujuttuja',
         createdAt: new Date(),
         updatedAt: new Date(),
+      },
+    ]);
+    await queryInterface.bulkInsert('apiStatistic', [
+      {
+        id: uuidv4(),
+        api: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        success: true,
+        statisticType: 'Get Item From MT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    await queryInterface.bulkInsert('apiStatistic', [
+      {
+        id: uuidv4(),
+        api: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        success: true,
+        statisticType: 'Get Item From MT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    await queryInterface.bulkInsert('apiStatistic', [
+      {
+        id: uuidv4(),
+        api: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        success: false,
+        statisticType: 'Get Item From MT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    await queryInterface.bulkInsert('apiStatistic', [
+      {
+        id: uuidv4(),
+        api: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        success: true,
+        statisticType: 'Get Item From MT',
+        createdAt: new Date(2021, 1, 2),
+        updatedAt: new Date(2021, 1, 2),
       },
     ]);
   },

--- a/cc-db-service/src/models/api.ts
+++ b/cc-db-service/src/models/api.ts
@@ -19,7 +19,7 @@ export const Api = sequelize.define(
     },
     authEndpoint: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
   },
   { freezeTableName: true, tableName: 'apiConfiguration' }

--- a/cc-db-service/src/models/apiStatistic.ts
+++ b/cc-db-service/src/models/apiStatistic.ts
@@ -22,10 +22,6 @@ export const ApiStatistic = sequelize.define(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    timeStamp: {
-      type: DataTypes.DATE,
-      allowNull: false,
-    },
   },
   { freezeTableName: true, tableName: 'apiStatistic' }
 );

--- a/cc-db-service/src/routes/apiRoutes.ts
+++ b/cc-db-service/src/routes/apiRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 
-import { getApis, getApi } from '../services/apiService';
+import { getApis, getApi, getApiStatistics, getApiStatisticsCounts, postApiStatistics } from '../services/apiService';
 import { HttpResponseError } from '../types';
 
 export const apiRoutes = Router();
@@ -28,6 +28,48 @@ apiRoutes.get(
     try {
       const apis = await getApi(_request.params.apiId);
       response.status(200).json(apis);
+    } catch (err:any) {
+      const httpError:HttpResponseError = {
+        message: err.message,
+        status: 500,
+        error: err
+      };
+      next(httpError);
+    }
+  }
+);
+
+apiRoutes.get(
+  '/apistatistics/:apiName/:statisticType',
+  async (_request: Request, response: Response, next: NextFunction) => {
+    try {
+      const apiStatistics = await getApiStatistics(_request.params.apiName, _request.params.statisticType);
+      const counts = await getApiStatisticsCounts(_request.params.apiName, _request.params.statisticType);
+      const statisticsResponse = {
+        statisticType: _request.params.statisticType,
+        apiName: _request.params.apiName,
+        successCount: counts.successCount,
+        failureCount: counts.failureCount,
+        daily: apiStatistics
+      }
+      response.status(200).json(statisticsResponse);
+    } catch (err:any) {
+      const httpError:HttpResponseError = {
+        message: err.message,
+        status: 500,
+        error: err
+      };
+      next(httpError);
+    }
+  }
+);
+
+apiRoutes.post(
+  '/apistatistics/:apiName/:statisticType',
+  async (_request: Request, response: Response, next: NextFunction) => {
+    try {
+      const newStatistic = await postApiStatistics(_request.params.apiName, _request.params.statisticType, _request.body);
+      response.status(200).json(newStatistic);
     } catch (err:any) {
       const httpError:HttpResponseError = {
         message: err.message,

--- a/cc-db-service/src/routes/apiRoutes.ts
+++ b/cc-db-service/src/routes/apiRoutes.ts
@@ -51,7 +51,7 @@ apiRoutes.get(
         successCount: counts.successCount,
         failureCount: counts.failureCount,
         daily: apiStatistics
-      }
+      };
       response.status(200).json(statisticsResponse);
     } catch (err:any) {
       const httpError:HttpResponseError = {

--- a/cc-db-service/src/routes/userRoutes.ts
+++ b/cc-db-service/src/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 
-import { createOrReturnUser, getUsers, getUserById } from '../services/userService';
+import { createOrReturnUser, getUsers, getUserById, getDailyUserCount, getUserCount } from '../services/userService';
 import { getItemsByUserId } from '../services/itemService';
 import { BackendToken, HttpResponseError } from '../types';
 import { getToken } from '../utils';
@@ -15,6 +15,27 @@ userRoutes.get(
     try {
       const users = await getUsers();
       response.status(200).json(users);
+    } catch (err:any) {
+      const httpError:HttpResponseError = {
+        message: err.message,
+        status: 500,
+        error: err
+      };
+      next(httpError);
+    }
+  }
+);
+
+userRoutes.get(
+  '/users/count',
+  async (_request: Request, response: Response, next: NextFunction) => {
+    try {
+      const usercount = await getUserCount();
+      const dailyUsersAdded = await getDailyUserCount();
+      response.status(200).json({
+        count: usercount,
+        daily: dailyUsersAdded
+      });
     } catch (err:any) {
       const httpError:HttpResponseError = {
         message: err.message,

--- a/cc-db-service/src/services/apiService.ts
+++ b/cc-db-service/src/services/apiService.ts
@@ -38,16 +38,17 @@ export const getApiStatistics = async (apiName: string, statisticType: string) =
       statisticType: statisticType
     },
   });
+  // eslint-disable-next-line
   const aggregates = new Array();
   for (let i=0;i<counts.length;i++) {
     const count = counts[i];
-    if (typeof count == "object") {
+    if (typeof count === "object") {
       const date = count.getDataValue("date");
       const countValue = count.getDataValue("count");
       const success = count.getDataValue("success");
       const arrayIndex = aggregates.findIndex(agg => agg.date === date);
       if (arrayIndex === -1) {
-        if (success == false) {
+        if (success === false) {
           aggregates.push({ date: date, failureCount: parseInt(countValue), successCount: 0 });
         }
         else {
@@ -56,7 +57,7 @@ export const getApiStatistics = async (apiName: string, statisticType: string) =
       }
       else {
         const agg = aggregates[arrayIndex];
-        if (success == false) {
+        if (success === false) {
           agg.failureCount = parseInt(countValue);
           aggregates[arrayIndex] = agg;
         }

--- a/cc-db-service/src/services/apiService.ts
+++ b/cc-db-service/src/services/apiService.ts
@@ -1,9 +1,126 @@
 import { Api } from '../models/api';
+import { ApiStatistic } from '../models/apiStatistic';
+import { Op, Sequelize } from 'sequelize';
+import { PostApiStatisticsInterface } from '../types';
 
 export const getApis = async () => {
-  return await Api.findAll();
+  return await Api.findAll({
+    where: {
+      authEndpoint: {
+        [Op.not]: null
+      }
+    }
+  });
 };
 
 export const getApi = async (apiId: string) => {
   return await Api.findOne({ where: { id: apiId } });
+};
+const getApiIdByName = async (apiName: string) => {
+  const api = await Api.findOne({ where: { name: apiName } });
+  if (api !== null) {
+    return api.getDataValue("id");
+  }
+  return null;
+};
+
+export const getApiStatistics = async (apiName: string, statisticType: string) => {
+  const apiId = await getApiIdByName(apiName);
+  // https://stackoverflow.com/questions/35073918/sequelize-grouping-by-date-disregarding-hours-minutes-seconds
+  const counts = await ApiStatistic.findAll({
+    attributes: [
+        [Sequelize.literal(`DATE("createdAt")`), 'date'],
+        [Sequelize.literal(`COUNT(*)`), 'count'],
+        'success',
+    ],
+    group: ['date', 'success'],
+    where: {
+      statisticType: statisticType
+    },
+  });
+  const aggregates = new Array();
+  for (let i=0;i<counts.length;i++) {
+    const count = counts[i];
+    if (typeof count == "object") {
+      const date = count.getDataValue("date");
+      const countValue = count.getDataValue("count");
+      const success = count.getDataValue("success");
+      const arrayIndex = aggregates.findIndex(agg => agg.date === date);
+      if (arrayIndex === -1) {
+        if (success == false) {
+          aggregates.push({ date: date, failureCount: parseInt(countValue), successCount: 0 });
+        }
+        else {
+          aggregates.push({ date: date, successCount: parseInt(countValue), failureCount: 0 });
+        }
+      }
+      else {
+        const agg = aggregates[arrayIndex];
+        if (success == false) {
+          agg.failureCount = parseInt(countValue);
+          aggregates[arrayIndex] = agg;
+        }
+        else {
+          agg.successCount = parseInt(countValue);
+          aggregates[arrayIndex] = agg;
+        }
+      }
+      
+    }
+  }
+  return aggregates;
+};
+
+export const getApiStatisticsCounts = async (apiName: string, statisticType: string) => {
+  const apiId = await getApiIdByName(apiName);
+  // https://stackoverflow.com/questions/35073918/sequelize-grouping-by-date-disregarding-hours-minutes-seconds
+  const counts = await ApiStatistic.findAll({
+    attributes: [
+        [Sequelize.literal(`COUNT(*)`), 'count'],
+        'success',
+    ],
+    group: ['success'],
+    where: {
+      statisticType: statisticType
+    },
+  });
+  const aggregates = {
+    failureCount: 0,
+    successCount: 0
+  };
+  for (let i=0;i<counts.length;i++) {
+    const count = counts[i];
+    if (typeof count === "object") {
+      const countValue = counts[i].getDataValue("count");
+      const success = counts[i].getDataValue("success");
+      if (success === false) {
+        aggregates.failureCount = countValue;
+      }
+      if (success === true) {
+        aggregates.successCount = countValue;
+      }
+    }
+  }
+  return aggregates;
+};
+
+
+export const postApiStatistics = async (apiName: string, statisticType: string, requestBody: PostApiStatisticsInterface) => {
+  const apiId = await getApiIdByName(apiName);
+  const success = requestBody.success;
+  if (requestBody.id) {
+    return await ApiStatistic.create({
+      id: requestBody.id,
+      api: apiId,
+      success: success,
+      statisticType: statisticType
+    });
+  }
+  else {
+    return await ApiStatistic.create({
+      api: apiId,
+      success: success,
+      statisticType: statisticType
+    });
+  }
 };

--- a/cc-db-service/src/services/userService.ts
+++ b/cc-db-service/src/services/userService.ts
@@ -38,10 +38,10 @@ export const getDailyUserCount = async () => {
     ],
     group: ['date'],
   });
-  const aggregates = new Array();
+  const aggregates = [];
   for (let i=0;i<counts.length;i++) {
     const count = counts[i];
-    if (typeof count == "object") {
+    if (typeof count === "object") {
       aggregates.push({ date: count.getDataValue("date"), count: count.getDataValue("count") });
     }
   }

--- a/cc-db-service/src/services/userService.ts
+++ b/cc-db-service/src/services/userService.ts
@@ -1,4 +1,5 @@
 import { User } from '../models/user';
+import { Sequelize } from 'sequelize';
 
 export const getUsers = async () => {
   return await User.findAll({ include: { all: true } });
@@ -24,4 +25,25 @@ export const createOrReturnUser = async (username: string, api: string, id: stri
       id: id
     });
   }
+};
+export const getUserCount = async () => {
+  return await User.count();
+};
+export const getDailyUserCount = async () => {
+  // https://stackoverflow.com/questions/35073918/sequelize-grouping-by-date-disregarding-hours-minutes-seconds
+  const counts = await User.findAll({
+    attributes: [
+        [Sequelize.literal(`DATE("createdAt")`), 'date'],
+        [Sequelize.literal(`COUNT(*)`), 'count']
+    ],
+    group: ['date'],
+  });
+  const aggregates = new Array();
+  for (let i=0;i<counts.length;i++) {
+    const count = counts[i];
+    if (typeof count == "object") {
+      aggregates.push({ date: count.getDataValue("date"), count: count.getDataValue("count") });
+    }
+  }
+  return aggregates;
 };

--- a/cc-db-service/src/types.ts
+++ b/cc-db-service/src/types.ts
@@ -17,3 +17,7 @@ export interface ItemType {
   transferTime: string;
   collectionId: string;
 }
+export interface PostApiStatisticsInterface {
+  id?: string;
+  success: boolean;
+}


### PR DESCRIPTION
Added new routes to cc-db-service:
- GET and POST /v1/apistatistics/:apiName/:statisticType
- GET /v1/users/count


Now cc-backend will automatically collect statistics, when:
- Getting unique item from PK -> statistic is added, with id = item id, api = pk api id, success = true and statisticType = unique
- Trying to POST advert to MT -> statistic is added, with id = generated id, api = mt api id, success = true/false depending if failed and statisticType = adverts

To test this out, run the whole thing with docker and try out the getItems route from cc-backend (or login via UI, it will get your own items) and try out the post advert route from cc-backend. then you can check out the statistics from cc-db-service routes: http://127.0.0.1:4001/v1/apistatistics/Materiaalitori/adverts and http://127.0.0.1:4001/v1/apistatistics/Purkukartoitus/unique